### PR TITLE
Fix dynamic name for Basic Electrics

### DIFF
--- a/localization/braz_por/real_companies_l_braz_por.yml
+++ b/localization/braz_por/real_companies_l_braz_por.yml
@@ -198,4 +198,6 @@ l_braz_por:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Energia Elétrica"
+ company_basic_electrics_dynamic_name_tag_plural: "Energia Elétrica"

--- a/localization/english/real_companies_l_english.yml
+++ b/localization/english/real_companies_l_english.yml
@@ -198,4 +198,6 @@ l_english:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Electric Power"
+ company_basic_electrics_dynamic_name_tag_plural: "Electric Power"

--- a/localization/french/real_companies_l_french.yml
+++ b/localization/french/real_companies_l_french.yml
@@ -198,4 +198,6 @@ l_french:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "électricité"
+ company_basic_electrics_dynamic_name_tag_plural: "électricité"

--- a/localization/german/real_companies_l_german.yml
+++ b/localization/german/real_companies_l_german.yml
@@ -198,4 +198,6 @@ l_german:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Elektrizität"
+ company_basic_electrics_dynamic_name_tag_plural: "Elektrizität"

--- a/localization/japanese/real_companies_l_japanese.yml
+++ b/localization/japanese/real_companies_l_japanese.yml
@@ -198,4 +198,6 @@ l_japanese:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "電力"
+ company_basic_electrics_dynamic_name_tag_plural: "電力"

--- a/localization/korean/real_companies_l_korean.yml
+++ b/localization/korean/real_companies_l_korean.yml
@@ -198,4 +198,6 @@ l_korean:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "전력"
+ company_basic_electrics_dynamic_name_tag_plural: "전력"

--- a/localization/polish/real_companies_l_polish.yml
+++ b/localization/polish/real_companies_l_polish.yml
@@ -198,4 +198,6 @@ l_polish:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Energia elektryczna"
+ company_basic_electrics_dynamic_name_tag_plural: "Energia elektryczna"

--- a/localization/russian/real_companies_l_russian.yml
+++ b/localization/russian/real_companies_l_russian.yml
@@ -198,4 +198,6 @@ l_russian:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Унгарище Аллгемеине Електризитацгеселлщафт"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Стеирище Вассеркрафт У. Електризитацгеселлщафт (Стеваг)"
  company_ottoman_electric_company: "Оттоман Електрик Компаны"
- company_societe_delectroottomane: "Сокиете Делектрооттомане"
+company_societe_delectroottomane: "Сокиете Делектрооттомане"
+ company_basic_electrics_dynamic_name_tag_singular: "электроэнергии"
+ company_basic_electrics_dynamic_name_tag_plural: "электроэнергия"

--- a/localization/simp_chinese/real_companies_l_simp_chinese.yml
+++ b/localization/simp_chinese/real_companies_l_simp_chinese.yml
@@ -198,4 +198,6 @@ l_simp_chinese:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "电力"
+ company_basic_electrics_dynamic_name_tag_plural: "电力"

--- a/localization/spanish/real_companies_l_spanish.yml
+++ b/localization/spanish/real_companies_l_spanish.yml
@@ -198,4 +198,6 @@ l_spanish:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Electricidad"
+ company_basic_electrics_dynamic_name_tag_plural: "Electricidad"

--- a/localization/turkish/real_companies_l_turkish.yml
+++ b/localization/turkish/real_companies_l_turkish.yml
@@ -198,4 +198,6 @@ l_turkish:
  company_ungarische_allgemeine_elektrizitatsgesellschaft: "Ungarische Allgemeine Elektrizitäts‑Gesellschaft"
  company_steirische_wasserkraft_u_elektrizitatsgesellschaft_stewag: "Steirische Wasserkraft‑ u. Elektrizitäts‑Gesellschaft (STEWAG)"
  company_ottoman_electric_company: "Ottoman Electric Company"
- company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+company_societe_delectroottomane: "Société d’Électro‑Ottomane"
+ company_basic_electrics_dynamic_name_tag_singular: "Elektrik Enerjisi"
+ company_basic_electrics_dynamic_name_tag_plural: "Elektrik Enerjisi"


### PR DESCRIPTION
## Summary
- override `basic_electrics` dynamic names so that power companies don't sound like electronics firms

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859c3132d10832e89e744b952ce00d1