### PR TITLE
Add pre-1836 company history and slot bonus modifier

### DIFF
--- a/common/history/countries/00_rc_pre1836_companies.txt
+++ b/common/history/countries/00_rc_pre1836_companies.txt
@@ -1,0 +1,201 @@
+COUNTRIES = {
+    c:AUS = {
+        add_company = company_type:company_osterreichische_lloyd
+        company:company_osterreichische_lloyd = {
+            set_company_establishment_date = 1833.1.1
+            set_company_state_region = s:STATE_AUSTRIA
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_kaiserlich_koniglich_staatsbahnen
+        company:company_kaiserlich_koniglich_staatsbahnen = {
+            set_company_establishment_date = 1810.1.1
+            set_company_state_region = s:STATE_AUSTRIA
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:FRA = {
+        add_company = company_type:company_compagnie_des_mines_d_anzin
+        company:company_compagnie_des_mines_d_anzin = {
+            set_company_establishment_date = 1757.1.1
+            set_company_state_region = s:STATE_ILE_DE_FRANCE
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_dollfus_mieg_et_compagnie
+        company:company_dollfus_mieg_et_compagnie = {
+            set_company_establishment_date = 1746.1.1
+            set_company_state_region = s:STATE_ALSACE_LORRAINE
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_peugeot
+        company:company_peugeot = {
+            set_company_establishment_date = 1810.1.1
+            set_company_state_region = s:STATE_BURGUNDY
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_saint_gobain
+        company:company_saint_gobain = {
+            set_company_establishment_date = 1665.1.1
+            set_company_state_region = s:STATE_ILE_DE_FRANCE
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_aussedat_rey
+        company:company_aussedat_rey = {
+            set_company_establishment_date = 1785.1.1
+            set_company_state_region = s:STATE_SAVOY
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:PRU = {
+        add_company = company_type:company_friedrich_krupp_ag
+        company:company_friedrich_krupp_ag = {
+            set_company_establishment_date = 1811.1.1
+            set_company_state_region = s:STATE_RHINELAND
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_konigliche_porzellan_manufaktur_meissen
+        company:company_konigliche_porzellan_manufaktur_meissen = {
+            set_company_establishment_date = 1710.1.1
+            set_company_state_region = s:STATE_SAXONY
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_zanders_feinpapiere_ag
+        company:company_zanders_feinpapiere_ag = {
+            set_company_establishment_date = 1829.1.1
+            set_company_state_region = s:STATE_RHINELAND
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:ITA = {
+        add_company = company_type:company_beretta
+        company:company_beretta = {
+            set_company_establishment_date = 1526.1.1
+            set_company_state_region = s:STATE_LOMBARDY
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_g_ricordi_and_c
+        company:company_g_ricordi_and_c = {
+            set_company_establishment_date = 1808.1.1
+            set_company_state_region = s:STATE_LOMBARDY
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:JAP = {
+        add_company = company_type:company_kinkozan_sobei
+        company:company_kinkozan_sobei = {
+            set_company_establishment_date = 1645.1.1
+            set_company_state_region = s:STATE_KANSAI
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:TUR = {
+        add_company = company_type:company_tersanei_amire
+        company:company_tersanei_amire = {
+            set_company_establishment_date = 1450.1.1
+            set_company_state_region = s:STATE_EASTERN_THRACE
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:RUS = {
+        add_company = company_type:company_izhevsk_arms_plant
+        company:company_izhevsk_arms_plant = {
+            set_company_establishment_date = 1807.1.1
+            set_company_state_region = s:STATE_PERM
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_russian_american_company
+        company:company_russian_american_company = {
+            set_company_establishment_date = 1799.1.1
+            set_company_state_region = s:STATE_INGRIA
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_savva_morozov_and_sons
+        company:company_savva_morozov_and_sons = {
+            set_company_establishment_date = 1823.1.1
+            set_company_state_region = s:STATE_MOSCOW
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_tula_arms_plant
+        company:company_tula_arms_plant = {
+            set_company_establishment_date = 1712.1.1
+            set_company_state_region = s:STATE_MOSCOW
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:GBR = {
+        add_company = company_type:company_arthur_guinness_son_and_co_ltd
+        company:company_arthur_guinness_son_and_co_ltd = {
+            set_company_establishment_date = 1759.1.1
+            set_company_state_region = s:STATE_LEINSTER
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_great_western_railway
+        company:company_great_western_railway = {
+            set_company_establishment_date = 1833.1.1
+            set_company_state_region = s:STATE_HOME_COUNTIES
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_jandp_coats
+        company:company_jandp_coats = {
+            set_company_establishment_date = 1826.1.1
+            set_company_state_region = s:STATE_LOWLANDS
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_royal_small_arms_factory
+        company:company_royal_small_arms_factory = {
+            set_company_establishment_date = 1816.1.1
+            set_company_state_region = s:STATE_HOME_COUNTIES
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_webley_and_scott
+        company:company_webley_and_scott = {
+            set_company_establishment_date = 1834.1.1
+            set_company_state_region = s:STATE_MIDLANDS
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    c:USA = {
+        add_company = company_type:company_baltimore_and_ohio_railroad
+        company:company_baltimore_and_ohio_railroad = {
+            set_company_establishment_date = 1827.1.1
+            set_company_state_region = s:STATE_MARYLAND
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_remington_arms
+        company:company_remington_arms = {
+            set_company_establishment_date = 1816.1.1
+            set_company_state_region = s:STATE_NEW_YORK
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+
+        add_company = company_type:company_william_cramp_and_sons
+        company:company_william_cramp_and_sons = {
+            set_company_establishment_date = 1825.1.1
+            set_company_state_region = s:STATE_PENNSYLVANIA
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+}

--- a/common/static_modifiers/rc_companies.txt
+++ b/common/static_modifiers/rc_companies.txt
@@ -1,0 +1,3 @@
+rc_company_slot_bonus = {
+    country_max_companies_add = 1
+}

--- a/localization/braz_por/real_companies_l_braz_por.yml
+++ b/localization/braz_por/real_companies_l_braz_por.yml
@@ -201,3 +201,5 @@ l_braz_por:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Energia Elétrica"
  company_basic_electrics_dynamic_name_tag_plural: "Energia Elétrica"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/english/real_companies_l_english.yml
+++ b/localization/english/real_companies_l_english.yml
@@ -201,3 +201,5 @@ l_english:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Electric Power"
  company_basic_electrics_dynamic_name_tag_plural: "Electric Power"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/french/real_companies_l_french.yml
+++ b/localization/french/real_companies_l_french.yml
@@ -201,3 +201,5 @@ l_french:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "électricité"
  company_basic_electrics_dynamic_name_tag_plural: "électricité"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/german/real_companies_l_german.yml
+++ b/localization/german/real_companies_l_german.yml
@@ -201,3 +201,5 @@ l_german:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Elektrizität"
  company_basic_electrics_dynamic_name_tag_plural: "Elektrizität"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/japanese/real_companies_l_japanese.yml
+++ b/localization/japanese/real_companies_l_japanese.yml
@@ -202,3 +202,5 @@ l_japanese:
  company_basic_electrics_dynamic_name_tag_singular: "電力"
  company_basic_electrics_dynamic_name_tag_plural: "電力"
 
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/korean/real_companies_l_korean.yml
+++ b/localization/korean/real_companies_l_korean.yml
@@ -201,3 +201,5 @@ l_korean:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "전력"
  company_basic_electrics_dynamic_name_tag_plural: "전력"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/polish/real_companies_l_polish.yml
+++ b/localization/polish/real_companies_l_polish.yml
@@ -201,3 +201,5 @@ l_polish:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Energia elektryczna"
  company_basic_electrics_dynamic_name_tag_plural: "Energia elektryczna"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/russian/real_companies_l_russian.yml
+++ b/localization/russian/real_companies_l_russian.yml
@@ -201,3 +201,5 @@ l_russian:
 company_societe_delectroottomane: "Сокиете Делектрооттомане"
  company_basic_electrics_dynamic_name_tag_singular: "электроэнергии"
  company_basic_electrics_dynamic_name_tag_plural: "электроэнергия"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/simp_chinese/real_companies_l_simp_chinese.yml
+++ b/localization/simp_chinese/real_companies_l_simp_chinese.yml
@@ -201,3 +201,5 @@ l_simp_chinese:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "电力"
  company_basic_electrics_dynamic_name_tag_plural: "电力"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/spanish/real_companies_l_spanish.yml
+++ b/localization/spanish/real_companies_l_spanish.yml
@@ -201,3 +201,5 @@ l_spanish:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Electricidad"
  company_basic_electrics_dynamic_name_tag_plural: "Electricidad"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."

--- a/localization/turkish/real_companies_l_turkish.yml
+++ b/localization/turkish/real_companies_l_turkish.yml
@@ -201,3 +201,5 @@ l_turkish:
 company_societe_delectroottomane: "Société d’Électro‑Ottomane"
  company_basic_electrics_dynamic_name_tag_singular: "Elektrik Enerjisi"
  company_basic_electrics_dynamic_name_tag_plural: "Elektrik Enerjisi"
+  modifier_rc_company_slot_bonus: "Additional Company Slot"
+  modifier_rc_company_slot_bonus_desc: "This country temporarily gains an extra company slot."


### PR DESCRIPTION
## Summary
- create `rc_company_slot_bonus` static modifier increasing `country_max_companies_add`
- add `00_rc_pre1836_companies.txt` history file spawning historic companies before 1836 and granting a 100-year slot bonus
- localize the new modifier in all languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859d4361810832e8be3453ca5a664e8