### PR TITLE
Fix duplicate company logos

### DIFF
--- a/common/company_types/00_real_companies_generated.txt
+++ b/common/company_types/00_real_companies_generated.txt
@@ -1223,8 +1223,8 @@ company_deutsche_bank = {
 
 # Friedrich Krupp AG
 company_friedrich_krupp_ag = {
-    icon = "gfx/interface/icons/company_icons/custom_companies_placeholder.dds"
-    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_mining.dds"
+    icon = "gfx/interface/icons/company_icons/historical_company_icons/german_krupp.dds"
+    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_manufacturing_heavy.dds"
     # Founded 1811
     flavored_company = yes
     building_types = {
@@ -1607,8 +1607,8 @@ company_anglo_sicilian_sulphur_company_ltd = {
 
 # Gio. Ansaldo & C.
 company_gio_ansaldo_and_c = {
-    icon = "gfx/interface/icons/company_icons/custom_companies_placeholder.dds"
-    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_harbor_shipbuilding.dds"
+    icon = "gfx/interface/icons/company_icons/historical_company_icons/ansaldo.dds"
+    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_manufacturing_heavy.dds"
     # Founded 1853
     flavored_company = yes
     building_types = {
@@ -2104,8 +2104,8 @@ company_kinkozan_sobei = {
 
 # Mitsubishi Zaibatsu
 company_mitsubishi_zaibatsu = {
-    icon = "gfx/interface/icons/company_icons/custom_companies_placeholder.dds"
-    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_mining.dds"
+    icon = "gfx/interface/icons/company_icons/historical_company_icons/japanese_mitsubishi.dds"
+    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_manufacturing_heavy.dds"
     # Founded 1870
     flavored_company = yes
     building_types = {
@@ -2137,8 +2137,8 @@ company_mitsubishi_zaibatsu = {
 
 # Mitsui Zaibatsu
 company_mitsui_zaibatsu = {
-    icon = "gfx/interface/icons/company_icons/custom_companies_placeholder.dds"
-    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_plantation.dds"
+    icon = "gfx/interface/icons/company_icons/historical_company_icons/japanese_mitsui.dds"
+    background = "gfx/interface/icons/company_icons/company_backgrounds/comp_illu_manufacturing_light.dds"
     # Founded 1876
     flavored_company = yes
     building_types = {


### PR DESCRIPTION
## Summary
- copy historical logos for Krupp, Mitsubishi Zaibatsu, Mitsui Zaibatsu and Gio. Ansaldo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a0329b3f8832e9a081e6f02b102c3