### PR TITLE
Add founding event for Colt Firearms

### DIFF
--- a/common/on_actions/rc_company_foundings.txt
+++ b/common/on_actions/rc_company_foundings.txt
@@ -1,0 +1,5 @@
+on_game_started_after_lobby = {
+    effect = {
+        c:USA = { trigger_event = { id = company_foundings.1 days = 64 } }
+    }
+}

--- a/events/company_foundings_events.txt
+++ b/events/company_foundings_events.txt
@@ -1,0 +1,28 @@
+namespace = company_foundings
+
+# Colt Firearms Founded
+company_foundings.1 = {
+    type = country_event
+    placement = ROOT
+    title = company_foundings.1.t
+    desc = company_foundings.1.d
+    flavor = company_foundings.1.f
+
+    immediate = {
+        add_company = company_type:company_colt_s_patent_firearms_manufacturing_company
+        company:company_colt_s_patent_firearms_manufacturing_company = {
+            set_company_establishment_date = 1836.3.5
+            set_company_state_region = s:STATE_CONNECTICUT
+        }
+        create_building = {
+            building = building_arms_industry
+            level = 1
+        }
+        add_modifier = { name = rc_company_slot_bonus days = 36500 }
+    }
+
+    option = {
+        name = company_foundings.1.a
+        default_option = yes
+    }
+}

--- a/localization/braz_por/real_companies_l_braz_por.yml
+++ b/localization/braz_por/real_companies_l_braz_por.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Energia Elétrica"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/english/real_companies_l_english.yml
+++ b/localization/english/real_companies_l_english.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Electric Power"
  rc_company_slot_bonus: "Additional Company Slot"
 
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/french/real_companies_l_french.yml
+++ b/localization/french/real_companies_l_french.yml
@@ -203,3 +203,7 @@ l_french:
  company_basic_electrics_dynamic_name_tag_plural: "électricité"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/german/real_companies_l_german.yml
+++ b/localization/german/real_companies_l_german.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Elektrizität"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/japanese/real_companies_l_japanese.yml
+++ b/localization/japanese/real_companies_l_japanese.yml
@@ -203,3 +203,7 @@ l_japanese:
  company_basic_electrics_dynamic_name_tag_plural: "電力"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/korean/real_companies_l_korean.yml
+++ b/localization/korean/real_companies_l_korean.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "전력"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/polish/real_companies_l_polish.yml
+++ b/localization/polish/real_companies_l_polish.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Energia elektryczna"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/russian/real_companies_l_russian.yml
+++ b/localization/russian/real_companies_l_russian.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "электроэнергия"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/simp_chinese/real_companies_l_simp_chinese.yml
+++ b/localization/simp_chinese/real_companies_l_simp_chinese.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "电力"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/spanish/real_companies_l_spanish.yml
+++ b/localization/spanish/real_companies_l_spanish.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Electricidad"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."

--- a/localization/turkish/real_companies_l_turkish.yml
+++ b/localization/turkish/real_companies_l_turkish.yml
@@ -203,3 +203,7 @@
  company_basic_electrics_dynamic_name_tag_plural: "Elektrik Enerjisi"
  rc_company_slot_bonus: "Additional Company Slot"
  
+ company_foundings.1.t: "Colt Firearms Founded"
+ company_foundings.1.d: "Samuel Colt has established his firearms company in Connecticut, pioneering revolver production."
+ company_foundings.1.f: "\"God made men, but Samuel Colt made them equal.\""
+ company_foundings.1.a: "Excellent."


### PR DESCRIPTION
## Summary
- add company founding event for Colt Firearms
- start Colt Firearms on March 5, 1836 via on_action hook
- give +1 company slot and build an arms industry in Connecticut
- localize event text in all languages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2ad08148832eb78581d106935caf